### PR TITLE
refactored to allow multi file sitemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,81 @@
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/flagrow/sitemap/blob/master/LICENSE.md) [![Latest Stable Version](https://img.shields.io/packagist/v/flagrow/sitemap.svg)](https://packagist.org/packages/flagrow/sitemap) [![Total Downloads](https://img.shields.io/packagist/dt/flagrow/sitemap.svg)](https://packagist.org/packages/flagrow/sitemap) [![Support Us](https://img.shields.io/badge/flagrow.io-support%20us-yellow.svg)](https://flagrow.io/support-us) [![Join our Discord server](https://discordapp.com/api/guilds/240489109041315840/embed.png)](https://flagrow.io/join-discord)
 
 This extension simply adds a sitemap to your forum.
-It can be accessed at `yourflarum.url/sitemap.xml`.
 
-There's no actual file on the server, the sitemap is generated on the fly and is always up to date.
+It uses default entries like Discussions and Users, but is also smart enough to conditionally add further entries
+based on the availability of extensions. This currently applies to flarum/tags and fof/pages. Other extensions
+can easily inject their own Resource information, check Extending below.
 
-This extension is compatible with the [Pages](https://discuss.flarum.org/d/2605-pages) extension.
+There are several modes to use the sitemap.
+
+### Runtime mode
+
+After enabling the extension the sitemap will be automatically be available and generated on the fly. It contains
+all Users, Discussions, Tags and Pages guests have access to.
+
+_Applicable to small forums, most likely on shared hosting environments, with discussions, users, tags and pages summed
+up being less than **10.000 items**._
+
+### Cache or disk mode
+
+You can set up a cron job that stores the sitemap into cache or onto disk. You need to run:
+
+```
+php flarum fof:sitemap:cache
+```
+
+To store the sitemap into cache. If you want to save the sitemap directly to your public folder, use the flag:
+
+```
+php flarum fof:sitemap:cache --write-xml-file
+```
+
+_Best for small forums, most likely on hosting environments allowing cronjobs and with discussions, users, tags and pages summed
+up being less than **50.000 items**._
+
+> 50.000 is the technical limit for sitemap files. If you have more entries to store, use the following option!
+
+### Multi file mode
+
+For larger forums you can set up a cron job that generates a sitemap index and compressed sitemap files.
+
+```
+php flarum fof:sitemap:multi
+```
+
+This command creates temporary files in your storage folder and if successful moves them over to the public
+directory automatically.
+
+_Best for larger forums, starting at 50.000 items._
+
+## Extending
+
+In order to register your own resource, create a class that implements `FoF\Sitemap\Resources\Resource`. Make sure
+to implement all abstract methods, check other implementations for examples. After this, register your 
+
+```php
+return [
+    new \FoF\Sitemap\Extend\RegisterResource(YourResource::class)
+];
+```
+That's it.
+
+## Commissioned
 
 The initial version of this extension was sponsored by [profesionalreview.com](https://www.profesionalreview.com/).
 
 ## Installation
 
-Use [Bazaar](https://discuss.flarum.org/d/5151-flagrow-bazaar-the-extension-marketplace) or install manually:
+Use [Bazaar](https://discuss.flarum.org/d/5151) or install manually:
 
 ```bash
-composer require flagrow/sitemap
+composer require fof/sitemap
 ```
 
 ## Updating
 
 ```bash
-composer update flagrow/sitemap
+composer update fof/sitemap
 php flarum migrate
 php flarum cache:clear
 ```
@@ -39,9 +94,7 @@ Please include as many details as possible. You can use `php flarum info` to get
 
 ## Links
 
-- [Flarum Discuss post](https://discuss.flarum.org/d/14941-flagrow-sitemap)
-- [Source code on GitHub](https://github.com/flagrow/sitemap)
-- [Report an issue](https://github.com/flagrow/sitemap/issues)
-- [Download via Packagist](https://packagist.org/packages/flagrow/sitemap)
-
-An extension by [Flagrow](https://flagrow.io/), a project of [Gravure](https://gravure.io/).
+- [Flarum Discuss post](https://discuss.flarum.org/d/14941)
+- [Source code on GitHub](https://github.com/FriendsOFlarum/sitemap)
+- [Report an issue](https://github.com/FriendsOFlarum/sitemap/issues)
+- [Download via Packagist](https://packagist.org/packages/fof/sitemap)

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "source": "https://github.com/FriendsOfFlarum/sitemap"
     },
     "require": {
-        "flarum/core": "^0.1.0-beta.11"
+        "flarum/core": ">=0.1.0-beta.12 <0.1.0-beta.14"
     },
     "extra": {
         "flarum-extension": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "flagrow/sitemap",
+    "name": "fof/sitemap",
     "description": "Generate a sitemap",
     "keywords": [
         "extension",
@@ -14,31 +14,39 @@
             "name": "Clark Winkelmann",
             "email": "clark.winkelmann@gmail.com",
             "homepage": "https://clarkwinkelmann.com/"
+        },
+        {
+            "name": "Daniël Klabbers",
+            "email": "daniel@klabbers.email",
+            "homepage": "http://luceos.com"
         }
     ],
     "support": {
-        "issues": "https://github.com/flagrow/sitemap/issues",
-        "source": "https://github.com/flagrow/sitemap"
+        "issues": "https://github.com/FriendsOfFlarum/sitemap/issues",
+        "source": "https://github.com/FriendsOfFlarum/sitemap"
     },
     "require": {
-        "flarum/core": "^0.1.0-beta.8"
+        "flarum/core": "^0.1.0-beta.11"
     },
     "extra": {
         "flarum-extension": {
-            "title": "Flagrow Sitemap",
+            "title": "FoF Sitemap",
             "icon": {
                 "name": "fas fa-sitemap",
-                "backgroundColor": "#f4f4f4",
-                "color": "#5f4bb6"
+                "backgroundColor": "#e74c3c",
+                "color": "#fff"
             }
         },
         "flagrow": {
             "discuss": "https://discuss.flarum.org/d/14941"
         }
     },
+    "replace": {
+        "flagrow/sitemap": "*"
+    },
     "autoload": {
         "psr-4": {
-            "Flagrow\\Sitemap\\": "src/"
+            "FoF\\Sitemap\\": "src/"
         }
     }
 }

--- a/extend.php
+++ b/extend.php
@@ -12,10 +12,12 @@ return [
     (new Extend\Routes('forum'))
         ->get('/sitemap.xml', 'flagrow-sitemap-index', SitemapController::class),
     function (Application $app, Dispatcher $events) {
+        $app->register(Providers\ResourceProvider::class);
         $app->register(Providers\ViewProvider::class);
 
         $events->listen(Configuring::class, function (Configuring $event) {
             $event->addCommand(Commands\CacheSitemapCommand::class);
+            $event->addCommand(Commands\MultiPageSitemapCommand::class);
         });
     },
 ];

--- a/extend.php
+++ b/extend.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Flagrow\Sitemap;
+namespace FoF\Sitemap;
 
-use Flagrow\Sitemap\Controllers\SitemapController;
+use FoF\Sitemap\Controllers\SitemapController;
 use Flarum\Console\Event\Configuring;
 use Flarum\Extend;
 use Flarum\Foundation\Application;
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 
 return [
     (new Extend\Routes('forum'))
-        ->get('/sitemap.xml', 'flagrow-sitemap-index', SitemapController::class),
+        ->get('/sitemap.xml', 'fof-sitemap-index', SitemapController::class),
     function (Application $app, Dispatcher $events) {
         $app->register(Providers\ResourceProvider::class);
         $app->register(Providers\ViewProvider::class);

--- a/src/Commands/CacheSitemapCommand.php
+++ b/src/Commands/CacheSitemapCommand.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Flagrow\Sitemap\Commands;
+namespace FoF\Sitemap\Commands;
 
-use Flagrow\Sitemap\SitemapGenerator;
+use FoF\Sitemap\SitemapGenerator;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\View\Factory;
 
 class CacheSitemapCommand extends Command
 {
-    protected $signature = 'flagrow:sitemap:cache {--write-xml-file : write to sitemap.xml}';
+    protected $signature = 'fof:sitemap:cache {--write-xml-file : write to sitemap.xml}';
     protected $description = 'Persists sitemap to cache and optionally to disk.';
 
     public function handle(Factory $view, Store $cache, SitemapGenerator $generator)
@@ -21,7 +21,7 @@ class CacheSitemapCommand extends Command
         if ($this->option('write-xml-file')) {
             @file_put_contents(
                 public_path('sitemap.xml'),
-                $view->make('flagrow-sitemap::sitemap')->with('urlset', $urlSet)->render()
+                $view->make('fof-sitemap::sitemap')->with('urlset', $urlSet)->render()
             );
         }
     }

--- a/src/Commands/CacheSitemapCommand.php
+++ b/src/Commands/CacheSitemapCommand.php
@@ -16,7 +16,7 @@ class CacheSitemapCommand extends Command
     {
         $urlSet = $generator->getUrlSet();
 
-        $cache->forever('flagrow.sitemap', $urlSet);
+        $cache->forever('fof-sitemap', $urlSet);
 
         if ($this->option('write-xml-file')) {
             @file_put_contents(

--- a/src/Commands/MultiPageSitemapCommand.php
+++ b/src/Commands/MultiPageSitemapCommand.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Flagrow\Sitemap\Commands;
+namespace FoF\Sitemap\Commands;
 
-use Flagrow\Sitemap\Disk\Index;
+use FoF\Sitemap\Disk\Index;
 use Flarum\Foundation\Application;
 use Illuminate\Console\Command;
 
 class MultiPageSitemapCommand extends Command
 {
-    protected $signature = 'flagrow:sitemap:multi-page';
+    protected $signature = 'fof:sitemap:multi';
     protected $description = 'Persists sitemap to disk into multiple gzipped files.';
 
     public function handle(Application $app)
@@ -17,7 +17,7 @@ class MultiPageSitemapCommand extends Command
 
         $index = new Index(
             $url,
-            $app->make('flagrow.sitemap.resources') ?? []
+            $app->make('fof.sitemap.resources') ?? []
         );
 
         $index->write();

--- a/src/Commands/MultiPageSitemapCommand.php
+++ b/src/Commands/MultiPageSitemapCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Flagrow\Sitemap\Commands;
+
+use Flagrow\Sitemap\Disk\Index;
+use Flarum\Foundation\Application;
+use Illuminate\Console\Command;
+
+class MultiPageSitemapCommand extends Command
+{
+    protected $signature = 'flagrow:sitemap:multi-page';
+    protected $description = 'Persists sitemap to disk into multiple gzipped files.';
+
+    public function handle(Application $app)
+    {
+        $url = $app->url();
+
+        $index = new Index(
+            $url,
+            $app->make('flagrow.sitemap.resources') ?? []
+        );
+
+        $index->write();
+
+        $index->publish();
+    }
+}

--- a/src/Controllers/SitemapController.php
+++ b/src/Controllers/SitemapController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Flagrow\Sitemap\Controllers;
+namespace FoF\Sitemap\Controllers;
 
-use Flagrow\Sitemap\SitemapGenerator;
+use FoF\Sitemap\SitemapGenerator;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\View\Factory;
 use Psr\Http\Message\ResponseInterface;
@@ -30,7 +30,7 @@ class SitemapController implements RequestHandlerInterface
     {
         $urlset = $this->cache->get('flagrow.sitemap') ?? $this->sitemap->getUrlSet();
 
-        return $this->view->make('flagrow-sitemap::sitemap')
+        return $this->view->make('fof-sitemap::sitemap')
             ->with('urlset', $urlset)
             ->render();
     }

--- a/src/Controllers/SitemapController.php
+++ b/src/Controllers/SitemapController.php
@@ -28,7 +28,7 @@ class SitemapController implements RequestHandlerInterface
 
     protected function render(ServerRequestInterface $request)
     {
-        $urlset = $this->cache->get('flagrow.sitemap') ?? $this->sitemap->getUrlSet();
+        $urlset = $this->cache->get('fof-sitemap') ?? $this->sitemap->getUrlSet();
 
         return $this->view->make('fof-sitemap::sitemap')
             ->with('urlset', $urlset)

--- a/src/Controllers/SitemapController.php
+++ b/src/Controllers/SitemapController.php
@@ -5,10 +5,10 @@ namespace FoF\Sitemap\Controllers;
 use FoF\Sitemap\SitemapGenerator;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\View\Factory;
+use Laminas\Diactoros\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response;
 
 class SitemapController implements RequestHandlerInterface
 {

--- a/src/Disk/Home.php
+++ b/src/Disk/Home.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Flagrow\Sitemap\Disk;
+
+use Carbon\Carbon;
+use Flagrow\Sitemap\Sitemap\Frequency;
+
+class Home extends Sitemap
+{
+    /**
+     * @var string
+     */
+    private $url;
+
+    public function __construct(string $url, string $tmpDir = null)
+    {
+        $this->tmpDir = $tmpDir;
+        $this->url = $url;
+    }
+
+    protected function chunk(string $directory): array
+    {
+        $filename = "sitemap-home.xml";
+
+        $stream = fopen($path = "$directory/$filename", 'w+');
+
+        fwrite($stream, <<<EOM
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+EOM
+        );
+
+        fwrite(
+            $stream,
+            $this->view()->make('flagrow-sitemap::url')->with('url', (object) [
+                'location' => $this->url,
+                'lastModified' => Carbon::now(),
+                'changeFrequency' => Frequency::DAILY,
+                'priority' => 0.9
+            ])->render()
+        );
+
+
+        fwrite($stream, <<<EOM
+</urlset>
+EOM
+        );
+
+        fclose($stream);
+
+        if ($gzipped = $this->gzCompressFile($path)) {
+//            unlink($path);
+        }
+
+        $path = str_replace($directory, null, $gzipped ?? $path);
+
+        return [$path];
+    }
+}

--- a/src/Disk/Home.php
+++ b/src/Disk/Home.php
@@ -49,7 +49,7 @@ EOM
         fclose($stream);
 
         if ($gzipped = $this->gzCompressFile($path)) {
-//            unlink($path);
+            unlink($path);
         }
 
         $path = str_replace($directory, null, $gzipped ?? $path);

--- a/src/Disk/Home.php
+++ b/src/Disk/Home.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Flagrow\Sitemap\Disk;
+namespace FoF\Sitemap\Disk;
 
 use Carbon\Carbon;
-use Flagrow\Sitemap\Sitemap\Frequency;
+use FoF\Sitemap\Sitemap\Frequency;
 
 class Home extends Sitemap
 {
@@ -32,9 +32,9 @@ EOM
 
         fwrite(
             $stream,
-            $this->view()->make('flagrow-sitemap::url')->with('url', (object) [
+            $this->view()->make('fof-sitemap::url')->with('url', (object) [
                 'location' => $this->url,
-                'lastModified' => Carbon::now(),
+                'lastModified' => $now = Carbon::now(),
                 'changeFrequency' => Frequency::DAILY,
                 'priority' => 0.9
             ])->render()
@@ -54,6 +54,6 @@ EOM
 
         $path = str_replace($directory, null, $gzipped ?? $path);
 
-        return [$path];
+        return [$path => $now];
     }
 }

--- a/src/Disk/Index.php
+++ b/src/Disk/Index.php
@@ -88,6 +88,8 @@ EOM
             public_path('sitemap.xml')
         );
 
+        if (! is_dir(public_path("sitemaps"))) mkdir(public_path("sitemaps"));
+
         foreach ($this->sitemaps as $sitemap) {
             copy(
                 storage_path("sitemaps-processing/sitemaps$sitemap"),

--- a/src/Disk/Index.php
+++ b/src/Disk/Index.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Flagrow\Sitemap\Disk;
+
+use Carbon\Carbon;
+use Flagrow\Sitemap\Resources\Resource;
+
+class Index
+{
+    /**
+     * @var array|Resource[]
+     */
+    protected $resources;
+
+    protected $sitemaps = [];
+    /**
+     * @var string
+     */
+    private $url;
+
+    public function __construct(string $url, array $resources)
+    {
+        $this->resources = $resources;
+        $this->url = $url;
+    }
+
+    public function write()
+    {
+        $this->saveHomepage();
+
+        foreach ($this->resources as $resource) {
+            $builder = $resource->query();
+
+            $sitemap = new Sitemap(
+                $builder->getModel()->getTable(),
+                $builder,
+                function ($model) use ($resource) {
+                    return (object) [
+                        'location' => $resource->url($model),
+                        'changeFrequency' => $resource->frequency(),
+                        'lastModified' => $resource->lastModifiedAt($model),
+                        'priority' => $resource->priority()
+                    ];
+                },
+                storage_path('sitemaps-processing/sitemaps')
+            );
+
+            array_push($this->sitemaps, ...$sitemap->write());
+        }
+
+        $this->saveIndexFile();
+    }
+
+    protected function saveIndexFile()
+    {
+        $now = Carbon::now()->toW3cString();
+
+        $stream = fopen(storage_path('sitemaps-processing/sitemap.xml'), 'w+');
+
+        fwrite($stream, <<<EOM
+<?xml version="1.0" encoding="UTF-8"?>
+   <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+EOM
+        );
+
+        foreach ($this->sitemaps as $sitemap) {
+            fwrite($stream, <<<EOM
+  <sitemap>
+      <loc>{$this->url}/sitemaps/{$sitemap}</loc>
+      <lastmod>{$now}</lastmod>
+   </sitemap>
+EOM
+            );
+        }
+
+        fwrite($stream, <<<EOM
+</sitemapindex>
+EOM
+        );
+
+        fclose($stream);
+    }
+
+    public function publish()
+    {
+        copy(
+            storage_path('sitemaps-processing/sitemap.xml'),
+            public_path('sitemap.xml')
+        );
+
+        foreach ($this->sitemaps as $sitemap) {
+            copy(
+                storage_path("sitemaps-processing/sitemaps$sitemap"),
+                public_path("sitemaps$sitemap")
+            );
+        }
+    }
+
+    protected function saveHomepage()
+    {
+        $home = new Home($this->url, storage_path('sitemaps-processing/sitemaps'));
+
+        array_push($this->sitemaps, ...$home->write());
+    }
+}

--- a/src/Disk/Sitemap.php
+++ b/src/Disk/Sitemap.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Flagrow\Sitemap\Disk;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Database\Eloquent\Builder;
+
+class Sitemap
+{
+    /**
+     * @var string
+     */
+    protected $filename;
+    /**
+     * @var Builder
+     */
+    protected $query;
+    /**
+     * @var callable
+     */
+    protected $callback;
+    /**
+     * @var string
+     */
+    protected $tmpDir;
+
+    public function __construct(string $filename, Builder $query, callable $callback, string $tmpDir = null)
+    {
+        $this->filename = $filename;
+        $this->query = $query;
+        $this->callback = $callback;
+        $this->tmpDir = $tmpDir;
+    }
+
+    /**
+     * Limit the number of entries to 50.000.
+     *
+     * @return array|string[]
+     */
+    public function write(): array
+    {
+        $directory = $this->tmpDir ?? public_path('sitemaps');
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        return $this->chunk($directory);
+    }
+
+    public function each($item)
+    {
+        if ($callback = $this->callback) {
+            $item = $callback($item);
+        }
+
+        return $item;
+    }
+
+    protected function gzCompressFile($source, $level = 9)
+    {
+        $dest = $source . '.gz';
+        $mode = 'wb' . $level;
+        $error = false;
+        if ($fp_out = gzopen($dest, $mode)) {
+            if ($fp_in = fopen($source,'rb')) {
+                while (!feof($fp_in))
+                    gzwrite($fp_out, fread($fp_in, 1024 * 512));
+                fclose($fp_in);
+            } else {
+                $error = true;
+            }
+            gzclose($fp_out);
+        } else {
+            $error = true;
+        }
+        if ($error)
+            return false;
+        else
+            return $dest;
+    }
+
+    protected function view(): Factory
+    {
+        return app(Factory::class);
+    }
+
+    /**
+     * @param string $directory
+     * @return array
+     */
+    protected function chunk(string $directory): array
+    {
+        $index = 0;
+        $filesWritten = [];
+
+        $this->query->chunk(5000, function ($query) use (&$index, &$filesWritten, $directory) {
+            $filename = "sitemap-{$this->filename}-{$index}.xml";
+
+            $stream = fopen($path = "$directory/$filename", 'w+');
+
+            fwrite($stream, <<<EOM
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+EOM
+            );
+
+            $query->each(function ($item) use (&$stream) {
+                $url = $this->each($item);
+
+                fwrite(
+                    $stream,
+                    $this->view()->make('flagrow-sitemap::url')->with('url', $url)->render()
+                );
+            });
+
+            fwrite($stream, <<<EOM
+</urlset>
+EOM
+            );
+
+            $index++;
+
+            fclose($stream);
+
+            if ($gzipped = $this->gzCompressFile($path)) {
+                unlink($path);
+            }
+
+
+            $filesWritten[] = str_replace($directory, null, $gzipped ?? $path);
+        });
+
+        return $filesWritten;
+    }
+}

--- a/src/Extend/RegisterResource.php
+++ b/src/Extend/RegisterResource.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FoF\Sitemap\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use FoF\Sitemap\Resources\Resource;
+use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
+
+class RegisterResource implements ExtenderInterface
+{
+    /**
+     * @var string
+     */
+    private $resource;
+
+    public function __construct(string $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        $container->resolving('fof.sitemap.resources', function (array $resources) use ($container) {
+            $resource = $container->make($this->resource);
+
+            if ($resource instanceof Resource) {
+                $resources[] = $resource;
+            } else {
+                throw new InvalidArgumentException("{$this->resource} has to extend " . Resource::class);
+            }
+
+            return $resources;
+        });
+    }
+}

--- a/src/Providers/ResourceProvider.php
+++ b/src/Providers/ResourceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Flagrow\Sitemap\Providers;
+
+use Flagrow\Sitemap\Resources;
+use Flarum\Extension\ExtensionManager;
+use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Tags\Tag;
+
+class ResourceProvider extends AbstractServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton('flagrow.sitemap.resources', function () {
+            return [
+                new Resources\User,
+                new Resources\Discussion
+            ];
+        });
+
+        $this->app->resolving('flagrow.sitemap.resources', function (array $resources) {
+            /** @var ExtensionManager $extensions */
+            $extensions = $this->app->make(ExtensionManager::class);
+
+            if ($extensions->isEnabled('flarum-tags') && class_exists(Tag::class)) {
+                $resources[] = new Resources\Tag;
+            }
+            if ($extensions->isEnabled('fof-pages')) {
+                $resources[] = new Resources\Page;
+            }
+        });
+    }
+}

--- a/src/Providers/ResourceProvider.php
+++ b/src/Providers/ResourceProvider.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Flagrow\Sitemap\Providers;
+namespace FoF\Sitemap\Providers;
 
-use Flagrow\Sitemap\Resources;
+use FoF\Sitemap\Resources;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\AbstractServiceProvider;
 use Flarum\Tags\Tag;
@@ -11,14 +11,14 @@ class ResourceProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('flagrow.sitemap.resources', function () {
+        $this->app->singleton('fof.sitemap.resources', function () {
             return [
                 new Resources\User,
                 new Resources\Discussion
             ];
         });
 
-        $this->app->resolving('flagrow.sitemap.resources', function (array $resources) {
+        $this->app->resolving('fof.sitemap.resources', function (array $resources) {
             /** @var ExtensionManager $extensions */
             $extensions = $this->app->make(ExtensionManager::class);
 

--- a/src/Providers/ViewProvider.php
+++ b/src/Providers/ViewProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flagrow\Sitemap\Providers;
+namespace FoF\Sitemap\Providers;
 
 use Flarum\Foundation\AbstractServiceProvider;
 
@@ -8,6 +8,6 @@ class ViewProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->app['view']->addNamespace('flagrow-sitemap', realpath(__DIR__ . '/../../views'));
+        $this->app['view']->addNamespace('fof-sitemap', realpath(__DIR__ . '/../../views'));
     }
 }

--- a/src/Resources/Discussion.php
+++ b/src/Resources/Discussion.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Flagrow\Sitemap\Resources;
+
+use Carbon\Carbon;
+use Flagrow\Sitemap\Sitemap\Frequency;
+use Flarum\Discussion\Discussion as Model;
+use Flarum\User\Guest;
+use Illuminate\Database\Eloquent\Builder;
+
+class Discussion extends Resource
+{
+    public function query(): Builder
+    {
+        return Model::whereVisibleTo(new Guest());
+    }
+
+    public function url($model): string
+    {
+        return $this->generateUrl("d/{$model->id}-{$model->slug}");
+    }
+
+    public function priority(): float
+    {
+        return 0.7;
+    }
+
+    public function frequency(): string
+    {
+        return Frequency::DAILY;
+    }
+
+    public function lastModifiedAt($model): Carbon
+    {
+        return $model->last_posted_at;
+    }
+}

--- a/src/Resources/Discussion.php
+++ b/src/Resources/Discussion.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Flagrow\Sitemap\Resources;
+namespace FoF\Sitemap\Resources;
 
 use Carbon\Carbon;
-use Flagrow\Sitemap\Sitemap\Frequency;
+use FoF\Sitemap\Sitemap\Frequency;
 use Flarum\Discussion\Discussion as Model;
 use Flarum\User\Guest;
 use Illuminate\Database\Eloquent\Builder;

--- a/src/Resources/Page.php
+++ b/src/Resources/Page.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Flagrow\Sitemap\Resources;
+
+use Carbon\Carbon;
+use Flagrow\Sitemap\Sitemap\Frequency;
+use FoF\Pages\Page as Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class Page extends Resource
+{
+    public function query(): Builder
+    {
+        return Model::query();
+    }
+
+    public function url($model): string
+    {
+        return $this->generateUrl("p/{$model->id}-{$model->slug}");
+    }
+
+    public function priority(): float
+    {
+        return 0.5;
+    }
+
+    public function frequency(): string
+    {
+        return Frequency::DAILY;
+    }
+
+    public function lastModifiedAt($model): Carbon
+    {
+        return $model->edit_time;
+    }
+}

--- a/src/Resources/Page.php
+++ b/src/Resources/Page.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Flagrow\Sitemap\Resources;
+namespace FoF\Sitemap\Resources;
 
 use Carbon\Carbon;
-use Flagrow\Sitemap\Sitemap\Frequency;
+use FoF\Sitemap\Sitemap\Frequency;
 use FoF\Pages\Page as Model;
 use Illuminate\Database\Eloquent\Builder;
 

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flagrow\Sitemap\Resources;
+namespace FoF\Sitemap\Resources;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Flagrow\Sitemap\Resources;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+
+abstract class Resource
+{
+    abstract public function url($model): string;
+
+    abstract public function query(): Builder;
+
+    abstract public function priority(): float;
+
+    abstract public function frequency(): string;
+
+    public function lastModifiedAt($model): Carbon
+    {
+        return Carbon::now();
+    }
+
+    protected function generateUrl($path): string
+    {
+        $url = app()->url();
+
+        return "$url/$path";
+    }
+}

--- a/src/Resources/Tag.php
+++ b/src/Resources/Tag.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Flagrow\Sitemap\Resources;
+
+use Flagrow\Sitemap\Sitemap\Frequency;
+use Flarum\Tags\Tag as Model;
+use Flarum\User\Guest;
+use Illuminate\Database\Eloquent\Builder;
+
+class Tag extends Resource
+{
+    public function query(): Builder
+    {
+        return Model::whereVisibleTo(new Guest());
+    }
+
+    public function url($model): string
+    {
+        return $this->generateUrl("t/{$model->slug}");
+    }
+
+    public function priority(): float
+    {
+        return 0.9;
+    }
+
+    public function frequency(): string
+    {
+        return Frequency::DAILY;
+    }
+}

--- a/src/Resources/Tag.php
+++ b/src/Resources/Tag.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Flagrow\Sitemap\Resources;
+namespace FoF\Sitemap\Resources;
 
-use Flagrow\Sitemap\Sitemap\Frequency;
+use FoF\Sitemap\Sitemap\Frequency;
 use Flarum\Tags\Tag as Model;
 use Flarum\User\Guest;
 use Illuminate\Database\Eloquent\Builder;

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Flagrow\Sitemap\Resources;
+
+use Flagrow\Sitemap\Sitemap\Frequency;
+use Flarum\User\User as Model;
+use Flarum\User\Guest;
+use Illuminate\Database\Eloquent\Builder;
+
+class User extends Resource
+{
+    public function query(): Builder
+    {
+        return Model::whereVisibleTo(new Guest());
+    }
+
+    public function url($model): string
+    {
+        return $this->generateUrl("u/{$model->username}");
+    }
+
+    public function priority(): float
+    {
+        return 0.5;
+    }
+
+    public function frequency(): string
+    {
+        return Frequency::DAILY;
+    }
+}

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Flagrow\Sitemap\Resources;
+namespace FoF\Sitemap\Resources;
 
-use Flagrow\Sitemap\Sitemap\Frequency;
+use FoF\Sitemap\Sitemap\Frequency;
 use Flarum\User\User as Model;
 use Flarum\User\Guest;
 use Illuminate\Database\Eloquent\Builder;

--- a/src/Sitemap/Frequency.php
+++ b/src/Sitemap/Frequency.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flagrow\Sitemap\Sitemap;
+namespace FoF\Sitemap\Sitemap;
 
 class Frequency
 {

--- a/src/Sitemap/Url.php
+++ b/src/Sitemap/Url.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flagrow\Sitemap\Sitemap;
+namespace FoF\Sitemap\Sitemap;
 
 use Carbon\Carbon;
 

--- a/src/Sitemap/UrlSet.php
+++ b/src/Sitemap/UrlSet.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flagrow\Sitemap\Sitemap;
+namespace FoF\Sitemap\Sitemap;
 
 class UrlSet
 {

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Flagrow\Sitemap;
+namespace FoF\Sitemap;
 
 use Carbon\Carbon;
-use Flagrow\Sitemap\Resources\Resource;
-use Flagrow\Sitemap\Sitemap\Frequency;
-use Flagrow\Sitemap\Sitemap\UrlSet;
+use FoF\Sitemap\Resources\Resource;
+use FoF\Sitemap\Sitemap\Frequency;
+use FoF\Sitemap\Sitemap\UrlSet;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Application;
 use Sijad\Pages\Page;
@@ -29,7 +29,7 @@ class SitemapGenerator
 
         $urlSet->addUrl($url . '/', Carbon::now(), Frequency::DAILY, 0.9);
 
-        $resources = $this->app->make('flagrow.sitemap.resources') ?? [];
+        $resources = $this->app->make('fof.sitemap.resources') ?? [];
 
         /** @var Resource $resource */
         foreach ($resources as $resource) {

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -3,14 +3,11 @@
 namespace Flagrow\Sitemap;
 
 use Carbon\Carbon;
+use Flagrow\Sitemap\Resources\Resource;
 use Flagrow\Sitemap\Sitemap\Frequency;
 use Flagrow\Sitemap\Sitemap\UrlSet;
-use Flarum\Discussion\Discussion;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Application;
-use Flarum\Tags\Tag;
-use Flarum\User\Guest;
-use Flarum\User\User;
 use Sijad\Pages\Page;
 
 class SitemapGenerator
@@ -32,23 +29,17 @@ class SitemapGenerator
 
         $urlSet->addUrl($url . '/', Carbon::now(), Frequency::DAILY, 0.9);
 
-        User::whereVisibleTo(new Guest())->each(function (User $user) use (&$urlSet, $url) {
-            $urlSet->addUrl($url . '/u/' . $user->username, Carbon::now(), Frequency::DAILY, 0.5);
-        });
+        $resources = $this->app->make('flagrow.sitemap.resources') ?? [];
 
-        Discussion::whereVisibleTo(new Guest())->each(function (Discussion $discussion) use (&$urlSet, $url) {
-            $urlSet->addUrl($url . '/d/' . $discussion->id . '-' . $discussion->slug, $discussion->last_posted_at, Frequency::DAILY, '0.7');
-        });
-
-        if ($this->extensions->isEnabled('flarum-tags') && class_exists(Tag::class)) {
-            Tag::whereVisibleTo(new Guest())->each(function (Tag $tag) use (&$urlSet, $url) {
-                $urlSet->addUrl($url . '/t/' . $tag->slug, Carbon::now(), Frequency::DAILY, 0.9);
-            });
-        }
-
-        if ($this->extensions->isEnabled('sijad-pages') && class_exists(Page::class)) {
-            Page::query()->each(function (Page $page) use (&$urlSet, $url) {
-                $urlSet->addUrl($url . '/p/' . $page->id . '-' . $page->slug, $page->edit_time, Frequency::DAILY, 0.5);
+        /** @var Resource $resource */
+        foreach ($resources as $resource) {
+            $resource->query()->each(function ($model) use (&$urlSet, $resource) {
+                $urlSet->addUrl(
+                    $resource->url($model),
+                    $resource->lastModifiedAt($model),
+                    $resource->frequency(),
+                    $resource->priority()
+                );
             });
         }
 

--- a/views/sitemap.blade.php
+++ b/views/sitemap.blade.php
@@ -8,17 +8,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 @foreach($urlset->urls as $url)
-    <url>
-        <loc>{!! htmlspecialchars($url->location, ENT_XML1) !!}</loc>
-@if ($url->lastModified)
-        <lastmod>{!! $url->lastModified->toW3cString() !!}</lastmod>
-@endif
-@if ($url->changeFrequency)
-        <changefreq>{!! htmlspecialchars($url->changeFrequency, ENT_XML1) !!}</changefreq>
-@endif
-@if ($url->priority)
-        <priority>{!! htmlspecialchars($url->priority, ENT_XML1) !!}</priority>
-@endif
-    </url>
+    @include('flagrow-sitemap::url', ['url' => $url])
 @endforeach
 </urlset>

--- a/views/sitemap.blade.php
+++ b/views/sitemap.blade.php
@@ -8,6 +8,6 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 @foreach($urlset->urls as $url)
-    @include('flagrow-sitemap::url', ['url' => $url])
+    @include('fof-sitemap::url', ['url' => $url])
 @endforeach
 </urlset>

--- a/views/url.blade.php
+++ b/views/url.blade.php
@@ -1,0 +1,12 @@
+<url>
+    <loc>{!! htmlspecialchars($url->location, ENT_XML1) !!}</loc>
+    @if ($url->lastModified)
+        <lastmod>{!! $url->lastModified->toW3cString() !!}</lastmod>
+    @endif
+    @if ($url->changeFrequency)
+        <changefreq>{!! htmlspecialchars($url->changeFrequency, ENT_XML1) !!}</changefreq>
+    @endif
+    @if ($url->priority)
+        <priority>{!! htmlspecialchars($url->priority, ENT_XML1) !!}</priority>
+    @endif
+</url>


### PR DESCRIPTION
- sijad pages moved to fof/pages
- refactored all resource definitions into their own classes, whether they should be used could also be moved into these resource definition classes possibly
- bound these resources into ioc
- resolved these resources for SitemapGenerator and MultiPageSitemapCommand; giving lots of flexibility
- MultiPageSitemapCommand will write multiple sitemap files per Model, it will chunk to prevent reaching the max. It also stores to the storage directory temporarily, then moves to public on completion and writing index. It also gzips ;)

Did I miss anything? Sorry that this pretty much rewrites all of it.