### PR TITLE
Use uid instead of username

### DIFF
--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -16,7 +16,7 @@ class User extends Resource
 
     public function url($model): string
     {
-        return $this->generateUrl("u/{$model->username}");
+        return $this->generateUrl("u/{$model->id}");
     }
 
     public function priority(): float


### PR DESCRIPTION
* Avoid 404 return when requesting a purely digital username
* Keep url after changing username, more search engine friendly