### PR TITLE
Use named routes instead of hard-coded URLs

### DIFF
--- a/src/Resources/Discussion.php
+++ b/src/Resources/Discussion.php
@@ -17,7 +17,9 @@ class Discussion extends Resource
 
     public function url($model): string
     {
-        return $this->generateUrl('d/' . $model->id . (trim($model->slug) ? '-' . $model->slug : ''));
+        return $this->generateRouteUrl('discussion', [
+            'id' => $model->id . (trim($model->slug) ? '-' . $model->slug : ''),
+        ]);
     }
 
     public function priority(): float

--- a/src/Resources/Page.php
+++ b/src/Resources/Page.php
@@ -35,7 +35,9 @@ class Page extends Resource
 
     public function url($model): string
     {
-        return $this->generateUrl('p/' . $model->id . (trim($model->slug) ? '-' . $model->slug : ''));
+        return $this->generateRouteUrl('pages.page', [
+            'id' => $model->id . (trim($model->slug) ? '-' . $model->slug : ''),
+        ]);
     }
 
     public function priority(): float

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -3,6 +3,7 @@
 namespace FoF\Sitemap\Resources;
 
 use Carbon\Carbon;
+use Flarum\Http\UrlGenerator;
 use Illuminate\Database\Eloquent\Builder;
 
 abstract class Resource
@@ -20,10 +21,32 @@ abstract class Resource
         return Carbon::now();
     }
 
+    /**
+     * Generates an absolute URL to an arbitrary path
+     * Not actually used by the extension anymore but kept for compatibility with third-party code extending this class
+     * @param $path
+     * @return string
+     */
     protected function generateUrl($path): string
     {
         $url = app()->url();
 
         return "$url/$path";
+    }
+
+    /**
+     * Generates an absolute URL to a named route
+     * @param $name
+     * @param array $parameters
+     * @return string
+     */
+    protected function generateRouteUrl($name, $parameters = []): string
+    {
+        /**
+         * @var $generator UrlGenerator
+         */
+        $generator = app(UrlGenerator::class);
+
+        return $generator->to('forum')->route($name, $parameters);
     }
 }

--- a/src/Resources/Tag.php
+++ b/src/Resources/Tag.php
@@ -16,7 +16,9 @@ class Tag extends Resource
 
     public function url($model): string
     {
-        return $this->generateUrl("t/{$model->slug}");
+        return $this->generateRouteUrl('tag', [
+            'slug' => $model->slug,
+        ]);
     }
 
     public function priority(): float

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -16,7 +16,9 @@ class User extends Resource
 
     public function url($model): string
     {
-        return $this->generateUrl("u/{$model->username}");
+        return $this->generateRouteUrl('user', [
+            'username' => $model->username,
+        ]);
     }
 
     public function priority(): float

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -5,6 +5,7 @@ namespace FoF\Sitemap;
 use Carbon\Carbon;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\Application;
+use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Sitemap\Resources\Resource;
 use FoF\Sitemap\Sitemap\Frequency;
@@ -14,28 +15,27 @@ class SitemapGenerator
 {
     protected $app;
     protected $extensions;
+    protected $settings;
+    protected $url;
 
-    public function __construct(Application $app, ExtensionManager $extensions)
+    public function __construct(Application $app, ExtensionManager $extensions, SettingsRepositoryInterface $settings, UrlGenerator $url)
     {
         $this->app = $app;
         $this->extensions = $extensions;
+        $this->settings = $settings;
+        $this->url = $url;
     }
 
     public function getUrlSet()
     {
         $urlSet = new UrlSet();
 
-        $url = $this->app->url();
-
         // Always add the homepage, whichever it is
-        $urlSet->addUrl($url . '/', Carbon::now(), Frequency::DAILY, 0.9);
-
-        /** @var SettingsRepositoryInterface $settings */
-        $settings = $this->app->make(SettingsRepositoryInterface::class);
+        $urlSet->addUrl($this->url->to('forum')->base() . '/', Carbon::now(), Frequency::DAILY, 0.9);
 
         // If the homepage is different from /all, also add /all
-        if ($settings->get('default_route') !== '/all') {
-            $urlSet->addUrl($url . '/all', Carbon::now(), Frequency::DAILY, 0.9);
+        if ($this->settings->get('default_route') !== '/all') {
+            $urlSet->addUrl($this->url->to('forum')->route('index'), Carbon::now(), Frequency::DAILY, 0.9);
         }
 
         $resources = $this->app->make('fof.sitemap.resources') ?? [];


### PR DESCRIPTION
There is no change in functionality, but this will make Sitemap compatible with my Custom Paths extension.