### PR TITLE
Fix issue #14 by modifying register callback

### DIFF
--- a/src/Extend/RegisterResource.php
+++ b/src/Extend/RegisterResource.php
@@ -37,13 +37,9 @@ class RegisterResource implements ExtenderInterface
 
             if ($resource instanceof Resource) {
                 $resources[] = $resource;
-                // confirms extension is added here.
-                app('log')->debug('[RegisterResource::extend] added '.get_class($resource));
             } else {
                 throw new InvalidArgumentException("{$this->resource} has to extend ".Resource::class);
             }
-            // here on extension register poiint we correctly see all core + extension resources.
-            app('log')->debug('[RegisterResource::extend] resolved '.count($resources).' resources.');
 
             return $resources;
         });

--- a/src/Extend/RegisterResource.php
+++ b/src/Extend/RegisterResource.php
@@ -32,14 +32,18 @@ class RegisterResource implements ExtenderInterface
 
     public function extend(Container $container, Extension $extension = null)
     {
-        $container->resolving('fof.sitemap.resources', function (array $resources) use ($container) {
+        $container->extend('fof.sitemap.resources', function (array $resources) use ($container) {
             $resource = $container->make($this->resource);
 
             if ($resource instanceof Resource) {
                 $resources[] = $resource;
+                // confirms extension is added here.
+                app('log')->debug('[RegisterResource::extend] added '.get_class($resource));
             } else {
                 throw new InvalidArgumentException("{$this->resource} has to extend ".Resource::class);
             }
+            // here on extension register poiint we correctly see all core + extension resources.
+            app('log')->debug('[RegisterResource::extend] resolved '.count($resources).' resources.');
 
             return $resources;
         });

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -49,9 +49,6 @@ class SitemapGenerator
 
         $resources = $this->app->make('fof.sitemap.resources') ?? [];
 
-        // confirms we now have all extensions.
-        app('log')->debug('[SitemapGenerator::getUrlSet] resolved '.count($resources).' resources.');
-
         /** @var FoF\Sitemap\Resources\Resource $resource */
         foreach ($resources as $resource) {
             $resource->query()->each(function ($model) use (&$urlSet, $resource) {

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -49,6 +49,9 @@ class SitemapGenerator
 
         $resources = $this->app->make('fof.sitemap.resources') ?? [];
 
+        // confirms we now have all extensions.
+        app('log')->debug('[SitemapGenerator::getUrlSet] resolved '.count($resources).' resources.');
+
         /** @var FoF\Sitemap\Resources\Resource $resource */
         foreach ($resources as $resource) {
             $resource->query()->each(function ($model) use (&$urlSet, $resource) {


### PR DESCRIPTION
I dont know if it is a pass by reference/copy issue, but modifying the array within a resolving callback was ignored  and so any custom resource classes registered there were ignored.  (see issue FriendsOfFlarum#14) 


but per illuminate docs we can wrap and augment existing instances using extend. 

I left debug logging in place to see differec.

### Before PR - extension resource was not included by SitemapGenerator
```
 
[2020-07-21 23:17:17] production.DEBUG: [Webbinaro\AdvCalendar] Resource Initialized  
[2020-07-21 23:17:17] production.DEBUG: [RegisterResource::extend] added Webbinaro\AdvCalendar\Integrations\EventResource  
[2020-07-21 23:17:17] production.DEBUG: [RegisterResource::extend] resolved 4 resources.  
[2020-07-21 23:17:17] production.DEBUG: [RegisterResource::extend] afterResolving 3 resources.  
[2020-07-21 23:17:17] production.DEBUG: [SitemapGenerator::getUrlSet] resolved 3 resources. 
```
^ note that the afterResolving callback and any calls to make (including generator's) do not include the modification to `resources` array.  (i think php copy-by-value-on-write  quirk, i dont know, it didnt work)


### After PR - modifications made by RegisterResource are picked up by Sitemap Generator 🎉 
```
  
[2020-07-22 00:00:55] production.DEBUG: [Webbinaro\AdvCalendar] Resource Initialized  
[2020-07-22 00:00:55] production.DEBUG: [RegisterResource::extend] added Webbinaro\AdvCalendar\Integrations\EventResource  
[2020-07-22 00:00:55] production.DEBUG: [RegisterResource::extend] resolved 4 resources.  
[2020-07-22 00:00:55] production.DEBUG: [RegisterResource::extend] afterResolving 4 resources.  
[2020-07-22 00:00:55] production.DEBUG: [SitemapGenerator::getUrlSet] resolved 4 resources.  
[2020-07-22 00:00:55] production.DEBUG: [Webbinaro\AdvCalendar] Resource Queried  

```