### PR TITLE
GH-28: Keep the sitemap index file

### DIFF
--- a/src/Commands/BuildSitemapCommand.php
+++ b/src/Commands/BuildSitemapCommand.php
@@ -157,7 +157,6 @@ class BuildSitemapCommand extends Command
         $index->publish();
 
         $this->forgetCache();
-        $this->forgetDisk();
 
         $this->info('FoF Sitemap: multi mode complete');
     }


### PR DESCRIPTION
Keep the index sitemap.xml we just created for the "multi sitemaps" mode. Note that the multi stiemap index uses /sitemap.xml which is the same as the "disk" mode uses. Therefore we should not call forgetDisk().
