### PR TITLE
Add pseudo resource for registering static URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ return [
 ];
 ```
 
+### Register a static URL
+
+Some pages of your forum might not be covered by the default resources. To add those urls to the sitemap there is a
+pseudo resource called `StaticUrls`. You can use the `RegisterStaticUrl` extender to add your own urls. The extender
+takes a route name as parameter, which will be resolved to a url using the `Flarum\Http\UrlGenerator` class.
+```php
+return [
+    (new \FoF\Sitemap\Extend\RegisterStaticUrl('reviews.index')),
+];
+```
+
 ### Force cache mode
 
 If you wish to force the use of cache mode, for example in complex hosted environments, this can be done by calling the extender:

--- a/composer.json
+++ b/composer.json
@@ -66,5 +66,9 @@
         "psr-4": {
             "FoF\\Sitemap\\": "src/"
         }
+    },
+    "require-dev": {
+        "flarum/tags": "*",
+        "fof/pages": "*"
     }
 }

--- a/src/Extend/RegisterStaticUrl.php
+++ b/src/Extend/RegisterStaticUrl.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of fof/sitemap.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ */
+
+namespace FoF\Sitemap\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use FoF\Sitemap\Resources\StaticUrls;
+use Illuminate\Contracts\Container\Container;
+
+class RegisterStaticUrl implements ExtenderInterface
+{
+	/**
+	 * Add a static url to the sitemap. Specify the route name.
+	 *
+	 * @param string $routeName
+	 */
+	public function __construct(
+		private string $routeName
+	) {
+	}
+
+	public function extend(Container $container, Extension $extension = null)
+	{
+		StaticUrls::addRoute($this->routeName);
+	}
+}

--- a/src/Extend/RegisterStaticUrl.php
+++ b/src/Extend/RegisterStaticUrl.php
@@ -19,18 +19,18 @@ use Illuminate\Contracts\Container\Container;
 
 class RegisterStaticUrl implements ExtenderInterface
 {
-	/**
-	 * Add a static url to the sitemap. Specify the route name.
-	 *
-	 * @param string $routeName
-	 */
-	public function __construct(
-		private string $routeName
-	) {
-	}
+    /**
+     * Add a static url to the sitemap. Specify the route name.
+     *
+     * @param string $routeName
+     */
+    public function __construct(
+        private string $routeName
+    ) {
+    }
 
-	public function extend(Container $container, Extension $extension = null)
-	{
-		StaticUrls::addRoute($this->routeName);
-	}
+    public function extend(Container $container, Extension $extension = null)
+    {
+        StaticUrls::addRoute($this->routeName);
+    }
 }

--- a/src/Generate/Generator.php
+++ b/src/Generate/Generator.php
@@ -88,7 +88,7 @@ class Generator
 
             $resource
                 ->query()
-                ->each(function (AbstractModel $item) use (&$output, &$set, $resource, &$remotes, &$i) {
+                ->each(function (AbstractModel|string $item) use (&$output, &$set, $resource, &$remotes, &$i) {
                     $url = new Url(
                         $resource->url($item),
                         $resource->lastModifiedAt($item),

--- a/src/Generate/Generator.php
+++ b/src/Generate/Generator.php
@@ -19,7 +19,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Sitemap\Deploy\DeployInterface;
 use FoF\Sitemap\Deploy\StoredSet;
 use FoF\Sitemap\Exceptions\SetLimitReachedException;
-use FoF\Sitemap\Resources\Resource;
+use FoF\Sitemap\Resources\Resource as AbstractResource;
 use FoF\Sitemap\Sitemap\Sitemap;
 use FoF\Sitemap\Sitemap\Url;
 use FoF\Sitemap\Sitemap\UrlSet;
@@ -69,7 +69,7 @@ class Generator
         $i = 0;
 
         foreach ($this->resources as $res) {
-            /** @var Resource $resource */
+            /** @var AbstractResource $resource */
             $resource = resolve($res);
 
             if (!$resource->enabled()) {

--- a/src/Generate/Generator.php
+++ b/src/Generate/Generator.php
@@ -69,7 +69,7 @@ class Generator
         $i = 0;
 
         foreach ($this->resources as $res) {
-            /** @var resource $resource */
+            /** @var Resource $resource */
             $resource = resolve($res);
 
             if (!$resource->enabled()) {

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -22,6 +22,7 @@ use FoF\Sitemap\Generate\Generator;
 use FoF\Sitemap\Resources\Discussion;
 use FoF\Sitemap\Resources\Page;
 use FoF\Sitemap\Resources\Resource;
+use FoF\Sitemap\Resources\StaticUrls;
 use FoF\Sitemap\Resources\Tag;
 use FoF\Sitemap\Resources\User;
 use Illuminate\Contracts\Container\Container;
@@ -32,6 +33,7 @@ class Provider extends AbstractServiceProvider
     {
         $this->container->singleton('fof-sitemaps.resources', function () {
             return [
+                StaticUrls::class,
                 Discussion::class,
                 Page::class,
                 Tag::class,

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -19,6 +19,7 @@ use Flarum\Http\SlugManager;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 abstract class Resource
 {
@@ -50,7 +51,7 @@ abstract class Resource
 
     abstract public function url($model): string;
 
-    abstract public function query(): Builder;
+    abstract public function query(): Builder|Collection;
 
     abstract public function priority(): float;
 

--- a/src/Resources/StaticUrls.php
+++ b/src/Resources/StaticUrls.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of fof/sitemap.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ */
+
+namespace FoF\Sitemap\Resources;
+
+use Carbon\Carbon;
+use FoF\Sitemap\Sitemap\Frequency;
+use Illuminate\Support\Collection;
+
+class StaticUrls extends Resource
+{
+    public static array $routes = [
+        'index'
+    ];
+
+    public static function addRoute(string $routeName)
+    {
+        static::$routes[] = $routeName;
+    }
+
+    public function query(): Collection
+    {
+        if (
+            // If the tags extension is enabled...
+            static::$extensionManager->isEnabled('flarum-tags')
+            // ...and route is not already added
+            && !in_array('tags', static::$routes)
+        ) {
+            static::addRoute('tags');
+        }
+
+        return collect(static::$routes);
+    }
+
+    public function url($routeName): string
+    {
+        return $this->generateRouteUrl($routeName);
+    }
+
+    public function priority(): float
+    {
+        return 0.5;
+    }
+
+    public function frequency(): string
+    {
+        return Frequency::DAILY;
+    }
+
+    public function lastModifiedAt($routeName): Carbon
+    {
+        return Carbon::now();
+    }
+}

--- a/src/Resources/StaticUrls.php
+++ b/src/Resources/StaticUrls.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Collection;
 class StaticUrls extends Resource
 {
     public static array $routes = [
-        'index'
+        'index',
     ];
 
     public static function addRoute(string $routeName)


### PR DESCRIPTION
**Changes proposed in this pull request:**
In this PR there is a new default Resource added to the Provider: `StaticUrls`. This is a *pseudo-resource*, as it isn't related to any model. It contains a list of route names that can be iterated to generate URLs to static pages of the app. By default there are 2 static pages: index and tags. Tags are only present in the list if the tags extension is activated.

A new Extender (`FoF\Sitemap\Extend\RegisterStaticUrl`) has been added, so that other extensions can add thier own static URLs to the list. Example: 

```php
new RegisterStaticUrl('reviews')
```

Other minor changes: 
- Add optional dependencies to `require-dev` so that type-hinting works properly
- Fix variable type in PHPDoc block for better type hinting

**Reviewers should focus on:**
- Making sure the changes didn't break the existing functionalities
- The static URLs are correctly added to the sitemap
- The new `RegisterStaticUrl` works as expected

**Screenshot**
```xml
<?xml version="1.0" encoding="UTF-8"?>

<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
    <loc>http://localhost:8888/all</loc>
            <lastmod>2023-04-05T08:27:44+00:00</lastmod>
                <changefreq>daily</changefreq>
                <priority>0.5</priority>
    </url>
    <url>
    <url>
    <loc>http://localhost:8888/tags</loc>
            <lastmod>2023-04-05T08:27:44+00:00</lastmod>
                <changefreq>daily</changefreq>
                <priority>0.5</priority>
    </url>
</urlset>
```

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
