### PR TITLE
fix: sitemap-xrobot-fix: Middleware added to add header tag X-Robots-Tag

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -77,4 +77,5 @@ return [
             (new Robots())
                 ->addEntry(TagEntry::class),
         ]),
+    (new Extend\Middleware('api'))->add(Middleware\ApiRobotsHeader::class),
 ];

--- a/src/Middleware/ApiRobotsHeader.php
+++ b/src/Middleware/ApiRobotsHeader.php
@@ -1,5 +1,16 @@
 <?php
-    namespace FoF\Sitemap\Middleware;
+
+/*
+ * This file is part of fof/sitemap.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ */
+
+namespace FoF\Sitemap\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Middleware/ApiRobotsHeader.php
+++ b/src/Middleware/ApiRobotsHeader.php
@@ -1,0 +1,25 @@
+<?php
+    namespace FoF\Sitemap\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ApiRobotsHeader implements MiddlewareInterface
+{
+    public function __construct(private string $value = 'noindex, nofollow')
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        if (!$response->hasHeader('X-Robots-Tag')) {
+            $response = $response->withHeader('X-Robots-Tag', $this->value);
+        }
+
+        return $response;
+    }
+}


### PR DESCRIPTION
1. Created a middleware folder and a ApiRobotsHeader file
2. In the extension the middleware file is added which hints that noindexing should be done on api's

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
