### PR TITLE
[2.x] fix: update XHTML namespace in sitemap URL set

### DIFF
--- a/views/urlset.blade.php
+++ b/views/urlset.blade.php
@@ -1,5 +1,5 @@
 <?php echo '<?xml version="1.0" encoding="UTF-8"?>'; ?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/TR/xhtml11/xhtml11_schema.html">
 @foreach($set->urls as $url)
     @include('fof-sitemap::url', ['url' => $url, 'settings' => $settings ?? null])
 @endforeach


### PR DESCRIPTION
'http://www.w3.org/1999/xhtml' doesn't support `<xhtml:link />`, causing sitemaps which contains `<xhtml:link />` to be displayed as plain text.
For more insights, check https://stackoverflow.com/questions/51923627/xml-sitemap-rendering-as-plain-text

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before
<img width="1079" height="308" alt="image" src="https://github.com/user-attachments/assets/b4ae02d9-b04e-4df7-aec4-5f0ae8ad7cb8" />


After
<img width="1056" height="417" alt="image" src="https://github.com/user-attachments/assets/41e3f377-f2f5-4e72-bfe6-bb622a78ae37" />

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
